### PR TITLE
Add support to find CertifyGood based upon minimal pURLs.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0.114"
 uuid = { version = "1.3.0", features = ["v4"] }
 chrono = { version = "0.4.23", features = ["serde"] }
 openvex = "0.1.0"
-packageurl = "0.3.0"
+packageurl = { version = "0.3.0", features = ["serde"] }
 async-trait = "0.1"
 async-nats = "0.29.0"
 serde_json = "1.0.56"

--- a/lib/src/graphql/good.rs
+++ b/lib/src/graphql/good.rs
@@ -1,0 +1,42 @@
+use self::certify_good_q1::{PackageQualifierSpec, PkgSpec};
+use graphql_client::GraphQLQuery;
+use packageurl::PackageUrl;
+use std::str::FromStr;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/schema.json",
+    query_path = "src/graphql/query/certify_good.gql",
+    response_derives = "Debug, Serialize, Deserialize"
+)]
+pub struct CertifyGoodQ1;
+
+impl TryFrom<&str> for PkgSpec {
+    type Error = anyhow::Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let purl = PackageUrl::from_str(s)?;
+        let mut qualifiers = Vec::new();
+        for (key, value) in purl.qualifiers().iter() {
+            qualifiers.push(PackageQualifierSpec {
+                key: key.to_string(),
+                value: Some(value.to_string()),
+            })
+        }
+
+        Ok(PkgSpec {
+            id: None,
+            type_: Some(purl.ty().to_string()),
+            namespace: purl.namespace().map(|s| s.to_string()),
+            name: Some(purl.name().to_string()),
+            subpath: purl.subpath().map(|s| s.to_string()),
+            version: purl.version().map(|s| s.to_string()),
+            qualifiers: if qualifiers.is_empty() {
+                None
+            } else {
+                Some(qualifiers)
+            },
+            match_only_empty_qualifiers: Some(false),
+        })
+    }
+}

--- a/lib/src/graphql/mod.rs
+++ b/lib/src/graphql/mod.rs
@@ -4,5 +4,6 @@ pub use client::*;
 mod cve;
 mod dependency;
 mod dependent;
+mod good;
 mod packages;
 mod vuln;

--- a/lib/src/graphql/query/certify_good.gql
+++ b/lib/src/graphql/query/certify_good.gql
@@ -1,0 +1,47 @@
+fragment allCertifyGoodTree on CertifyGood {
+  justification
+  subject {
+    __typename
+    ... on Package {
+      type
+      namespaces {
+        namespace
+        names {
+          name
+          versions {
+            version
+            qualifiers {
+              key
+              value
+            }
+            subpath
+          }
+        }
+      }
+    }
+    ... on Source {
+      type
+      namespaces {
+        namespace
+        names {
+          name
+          tag
+          commit
+        }
+      }
+    }
+    ... on Artifact {
+      algorithm
+      digest
+    }
+  }
+  origin
+  collector
+}
+
+query CertifyGoodQ1($package: PkgSpec) {
+  CertifyGood(certifyGoodSpec: { subject: {package: $package}}) {
+    ...allCertifyGoodTree
+  }
+}
+


### PR DESCRIPTION
eg, assuming a matching pURL has been CertifyGood'd:

    guac query good pkg:rpm///acl

results in

    [
      {
        "name": "acl",
        "namespace": "redhat",
        "qualifiers": {
          "arch": "ppc64le"
        },
        "subpath": null,
        "ty": "rpm",
        "version": "2.2.51-15.el7"
      }
    ]