### PR TITLE
build: remove env_logger

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,7 +12,6 @@ graphql_client = {version = "0.12.0", features = ["reqwest"]}
 reqwest = { version = "^0.11", features = ["json"] }
 anyhow = "1.0.39"
 log = "^0.4"
-env_logger = "^0.5"
 serde = "1.0.114"
 uuid = { version = "1.3.0", features = ["v4"] }
 chrono = { version = "0.4.23", features = ["serde"] }


### PR DESCRIPTION
This removes env_logger, which was also at a very old version. Beside that, a library shouldn't include env_logger, just "log".

Removing this removes a bunch of transient dependencies for users of this crate.